### PR TITLE
Introduce multi-platform images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU for multiarch builds
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx for multiarch builds
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata (tags, labels) for Docker image
         id: meta
         uses: docker/metadata-action@v3
@@ -49,10 +55,11 @@ jobs:
             type=edge,branch=main
 
       - name: Build and push docker image to dockerhub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: "./src"
           file: ./src/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/rebuild-release.yml
+++ b/.github/workflows/rebuild-release.yml
@@ -29,6 +29,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU for multiarch builds
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx for multiarch builds
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata (tags, labels) for Docker image
         id: meta
         uses: docker/metadata-action@v3
@@ -41,10 +47,11 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push docker image to dockerhub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: "./src"
           file: ./src/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This commit follows the [latest documentation of Docker's Github Action guides](https://docs.docker.com/build/ci/github-actions/multi-platform/) to build multi-architecture images.

This should allow publishing of `amd64` and `aarch64` containers, which can help users on ARM environments to avoid emulating all of nix.